### PR TITLE
Immer has been used to mutate the state in reducer

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const redux = require('redux');
 const createStore = redux.legacy_createStore;
 const middleware = redux.applyMiddleware;
 const { createLogger } = require('redux-logger');
+const produce = require('immer').produce;
 
 // Cake Types
 const MAKE_CAKE = 'MAKE_CAKE';
@@ -40,15 +41,13 @@ const initialIceCreamState = {
 const cakeReducer = (state = initialCakeState, { type, payload }) => {
 	switch (type) {
 		case MAKE_CAKE:
-			return {
-				...state,
-				noOfCake: state.noOfCake + 1,
-			};
+			return produce(state, draft => {
+				draft.noOfCake = state.noOfCake + 1;
+			});
 		case SELL_CAKE:
-			return {
-				...state,
-				noOfCake: state.noOfCake - 1,
-			};
+			return produce(state, draft => {
+				draft.noOfCake = state.noOfCake - 1;
+			});
 		default:
 			return state;
 	}
@@ -58,15 +57,13 @@ const cakeReducer = (state = initialCakeState, { type, payload }) => {
 const iceCreamReducer = (state = initialIceCreamState, { type, payload }) => {
 	switch (type) {
 		case MAKE_ICE_CREAM:
-			return {
-				...state,
-				noOfIceCream: state.noOfIceCream + 1,
-			};
+			return produce(state, draft => {
+				draft.noOfIceCream = state.noOfIceCream + 1;
+			});
 		case SELL_ICE_CREAM:
-			return {
-				...state,
-				noOfIceCream: state.noOfIceCream - 1,
-			};
+			return produce(state, draft => {
+				draft.noOfIceCream = state.noOfIceCream - 1;
+			});
 		default:
 			return state;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "immer": "^9.0.15",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6"
       }
@@ -28,6 +29,15 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
+    },
+    "node_modules/immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/redux": {
       "version": "4.2.0",
@@ -64,6 +74,11 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
+    },
+    "immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "redux": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "immer": "^9.0.15",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6"
   }


### PR DESCRIPTION
**Immer simplifies handling immutable data structures**

Immer can be used in any context in which immutable data structures need to be used. For example in combination with React state, React or Redux reducers, or configuration management. Immutable data structures allow for (efficient) change detection: if the reference to an object didn't change, the object itself did not change. In addition, it makes cloning relatively cheap: Unchanged parts of a data tree don't need to be copied and are shared in memory with older versions of the same state.